### PR TITLE
Update PyInstaller to fix security vulnerability

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,6 @@
-google-api-python-client>=1.7.3, <1.8
 openpyxl>=2.5.4, <2.6
 PuLP>=1.6.8, <1.7
 PyQt5>=5.11.2, <5.12
 PyQt5-sip>=4.19.12, <4.20
 QtPy>=1.4.2, <1.5
-PyInstaller>=3.3.1, <3.4
+PyInstaller>=3.6

--- a/src/services/scheduler.py
+++ b/src/services/scheduler.py
@@ -7,11 +7,6 @@ import time
 from datetime import datetime, timedelta
 
 import pulp
-from googleapiclient.discovery import build
-from httplib2 import Http
-from oauth2client import client
-from oauth2client import file as oauth_file
-from oauth2client import tools
 
 from constants import *
 


### PR DESCRIPTION
Vulnerability details: https://github.com/advisories/GHSA-7fcj-pq9j-wh2r

Also, remove old references to `google-api-client`